### PR TITLE
add SDF and rock-gazebo support

### DIFF
--- a/bin/rock-control_bot
+++ b/bin/rock-control_bot
@@ -97,15 +97,18 @@ require 'pry'
 ctrl_gui = Vizkit.default_loader.ControlUi
 ctrl_gui.configureUi(override_vel_limits, only_positive, no_effort, no_velocity, command_noise_std_dev)
 
-yaml_file_ext = [".yml", ".yaml"]
-urdf_file_ext = [".urdf", ".xml"]
+YAML_FILE_EXT = [".yml", ".yaml"]
+URDF_FILE_EXT = [".urdf", ".xml"]
 
-if yaml_file_ext.include? File.extname(model_file)
+model_file_ext = File.extname(model_file)
+
+if YAML_FILE_EXT.include?(model_file_ext)
     ctrl_gui.initFromYaml(model_file.dup)
-elsif urdf_file_ext.include? File.extname(model_file)
+elsif URDF_FILE_EXT.include?(model_file_ext)
     ctrl_gui.initFromURDF(model_file.dup)
 else
-    print "Invalid model file format. Accepts only ", yaml_file_ext, " or ", urdf_file_ext
+    puts "Invalid model file format. Got #{model_file_ext} but accepts only ", YAML_FILE_EXT, ", ", URDF_FILE_EXT, " or ", SDF_FILE_EXT
+    exit 1
 end
 
 if do_write

--- a/bin/rock-control_bot
+++ b/bin/rock-control_bot
@@ -99,6 +99,7 @@ ctrl_gui.configureUi(override_vel_limits, only_positive, no_effort, no_velocity,
 
 YAML_FILE_EXT = [".yml", ".yaml"]
 URDF_FILE_EXT = [".urdf", ".xml"]
+SDF_FILE_EXT = [".sdf", ".world"]
 
 model_file_ext = File.extname(model_file)
 
@@ -106,6 +107,11 @@ if YAML_FILE_EXT.include?(model_file_ext)
     ctrl_gui.initFromYaml(model_file.dup)
 elsif URDF_FILE_EXT.include?(model_file_ext)
     ctrl_gui.initFromURDF(model_file.dup)
+elsif SDF_FILE_EXT.include?(model_file_ext)
+    if !ctrl_gui.initFromSDF(model_file.dup)
+        puts "Failed to load #{model_file}"
+        exit 1
+    end
 else
     puts "Invalid model file format. Got #{model_file_ext} but accepts only ", YAML_FILE_EXT, ", ", URDF_FILE_EXT, " or ", SDF_FILE_EXT
     exit 1

--- a/bin/rock-control_bot
+++ b/bin/rock-control_bot
@@ -108,10 +108,7 @@ if YAML_FILE_EXT.include?(model_file_ext)
 elsif URDF_FILE_EXT.include?(model_file_ext)
     ctrl_gui.initFromURDF(model_file.dup)
 elsif SDF_FILE_EXT.include?(model_file_ext)
-    if !ctrl_gui.initFromSDF(model_file.dup)
-        puts "Failed to load #{model_file}"
-        exit 1
-    end
+    ctrl_gui.initFromSDF(model_file.dup)
 else
     puts "Invalid model file format. Got #{model_file_ext} but accepts only ", YAML_FILE_EXT, ", ", URDF_FILE_EXT, " or ", SDF_FILE_EXT
     exit 1

--- a/bin/rock-control_bot
+++ b/bin/rock-control_bot
@@ -50,19 +50,19 @@ rock-control_bot [options] /path/to/model/file
     end
     opt.on '--joint_command_port=TASK_CONTEXT_NAME:PORT_NAME', '-c=TASK_CONTEXT_NAME:PORT_NAME' , "Force joint command port to be PORT_NAME of task TASK_CONTEXT_NAME" do |val|
         splitted = val.split(':')
-        if splitted.size != 2
+        if splitted.size < 2
             raise("Definition of command port must follow the pattern 'TASK_CONTEXT_NAME:PORT_NAME'. Example: --joint_command_port=my_task:the_port")
         end
-        @command_task_name = splitted[0]
-        @command_port_name = splitted[1]
+        @command_task_name = splitted[0..-2].join(":")
+        @command_port_name = splitted[-1]
     end
     opt.on '--joint_state_port=TASK_CONTEXT_NAME:PORT_NAME', '-s=TASK_CONTEXT_NAME:PORT_NAME' , "Force joint state port to be PORT_NAME of task TASK_CONTEXT_NAME" do |val|
         splitted = val.split(':')
-        if splitted.size != 2
+        if splitted.size < 2
             raise("Definition of command port must follow the pattern 'TASK_CONTEXT_NAME:PORT_NAME'. Example: --joint_command_port=my_task:the_port")
         end
-        @state_task_name = splitted[0]
-        @state_port_name = splitted[1]
+        @state_task_name = splitted[0..-2].join(":")
+        @state_port_name = splitted[-1]
     end
 end
 
@@ -119,12 +119,9 @@ end
 
 if do_write
     command_task = Orocos::Async.proxy @command_task_name
-    
     command_port = command_task.port(@command_port_name)
-
     command_port.on_reachable do
-
-       print "Connected output to ", @command_task_name, ":", @command_port_name, "\n"
+       print "Connected output to task ", @command_task_name, ", port ", @command_port_name, "\n"
        ctrl_gui.enableSendCBs(true)
 
        ctrl_gui.connect(SIGNAL('sendSignal()')) do
@@ -141,7 +138,7 @@ if do_write
     end
 
     command_port.on_unreachable do
-        print "Not connected to port ", @command_task_name, ":", @command_port_name, "\n"
+        print "Not connected to task ", @command_task_name, ", port ", @command_port_name, "\n"
         ctrl_gui.checkKeepSendingCB(false)
         ctrl_gui.enableSendCBs(false)
 
@@ -154,7 +151,7 @@ if do_read
 
     state_port = state_task.port(@state_port_name)
     state_port.on_reachable do
-       print "Connected input to ", @state_task_name, ":", @state_port_name, "\n"
+       print "Connected input to task ", @state_task_name, ", port ", @state_port_name, "\n"
        ctrl_gui.enableUpdateCB(true)
     end
 
@@ -163,7 +160,7 @@ if do_read
     end
 
     state_port.on_unreachable do
-        print "Not connected to port ", @state_task_name, ":", @state_port_name, "\n"
+        print "Not connected to task ", @state_task_name, ", port ", @state_port_name, "\n"
         ctrl_gui.enableUpdateCB(false)
     end
 

--- a/manifest.xml
+++ b/manifest.xml
@@ -9,6 +9,7 @@
   <depend package="base/types" />
   <depend package="base/logging" />
   <depend package="control/urdfdom" />
+  <depend package="control/sdformat" />
   <depend package="gui/vizkit" />
   <depend package="yaml-cpp" />
 </package>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,7 +28,7 @@ rock_vizkit_widget(control_ui
     HEADERS ${HDRS}
     MOC ${MOC_HDRS}
     UI jointform.ui
-    DEPS_PKGCONFIG base-types base-lib QtCore QtGui urdfdom yaml-cpp base-logging
+    DEPS_PKGCONFIG base-types base-lib QtCore QtGui urdfdom yaml-cpp base-logging sdformat
     DEPS_CMAKE
     LIBS ${QT_QTCORE_LIBRARY} ${QT_QTGUI_LIBRARY} ${QT_QTOPENGL_LIBRARY} ${QT_QTDESIGNER_LIBRARY}
 )

--- a/src/ControlUi.cc
+++ b/src/ControlUi.cc
@@ -57,6 +57,24 @@ void ControlUi::configureUi(double override_vel_limit, bool positive_vel_only, b
     config.command_noise_std_dev = command_noise_std_dev;
 }
 
+void ControlUi::initFromFile(QString filepath, QString mode){
+    if (mode == "auto"){
+        QString ext = QFileInfo(filepath).suffix();
+        if (ext == "urdf")
+            return initFromURDF(filepath);
+        else if (ext == "sdf" || ext == "world")
+            return initFromSDF(filepath);
+        else if (ext == "yml")
+            return initFromYaml(filepath);
+    }
+    else if (mode == "urdf")
+        return initFromURDF(filepath);
+    else if (mode == "sdf")
+        return initFromSDF(filepath);
+    else if (mode == "yaml")
+        return initFromYaml(filepath);
+}
+
 void ControlUi::initFromURDF(QString filepath){
     std::ifstream file(filepath.toStdString().c_str());
     std::string xml((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());

--- a/src/ControlUi.cc
+++ b/src/ControlUi.cc
@@ -77,8 +77,13 @@ void ControlUi::initFromFile(QString filepath, QString mode){
 
 void ControlUi::initFromURDF(QString filepath){
     std::ifstream file(filepath.toStdString().c_str());
+    if (!file)
+        throw std::invalid_argument(filepath.toStdString() + " is not a valid file");
+
     std::string xml((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
     urdf::ModelInterfaceSharedPtr urdf_model = urdf::parseURDF(xml);
+    if (!urdf_model)
+        throw std::invalid_argument("cannot load data in " + filepath.toStdString() + " as URDF");
 
     std::map<std::string, urdf::JointSharedPtr >::iterator it;
     base::JointLimits limits;

--- a/src/ControlUi.cc
+++ b/src/ControlUi.cc
@@ -163,20 +163,14 @@ void ControlUi::initFromSDF(QString filePath)
 {
     sdf::SDFPtr sdf(new sdf::SDF);
 
-    if (!sdf::init(sdf)){
-        LOG_ERROR("unable to initialize sdf.");
-        return;
-    }
+    if (!sdf::init(sdf))
+        throw std::logic_error("unable to initialize the SDF structure");
 
-    if (!sdf::readFile(filePath.toStdString(), sdf)){
-        LOG_ERROR("unabled to read sdf file %s.", filePath.toStdString().c_str());
-        return;
-    }
+    if (!sdf::readFile(filePath.toStdString(), sdf))
+        throw std::logic_error("unable to read " + filePath.toStdString() + " as a SDF file");
 
-    if (!sdf->Root()->HasElement("model")){
-        LOG_ERROR("the <model> tag not exists");
-        return;
-    }
+    if (!sdf->Root()->HasElement("model"))
+        throw std::logic_error("SDF file " + filePath.toStdString() + " is not a model file (does not have a toplevel model tag)");
 
     sdf::ElementPtr sdf_model = sdf->Root()->GetElement("model");
     std::string model_name = sdf_model->Get<std::string>("name");

--- a/src/ControlUi.cc
+++ b/src/ControlUi.cc
@@ -6,6 +6,7 @@
 #include <QVBoxLayout>
 #include <QScrollArea>
 #include <yaml-cpp/yaml.h>
+#include <sdf/sdf.hh>
 
 ControlUi::ControlUi(QWidget *parent)
     : QWidget(parent)
@@ -130,6 +131,75 @@ void ControlUi::initFromYaml(QString filepath){
         }
 
         limits.elements.push_back(range);
+    }
+
+    initModel(limits);
+}
+
+void ControlUi::initFromSDF(QString filePath)
+{
+     sdf::SDFPtr sdf(new sdf::SDF);
+
+    if (!sdf::init(sdf)){
+        LOG_ERROR("unable to initialize sdf.");
+        return;
+    }
+
+    if (!sdf::readFile(filePath.toStdString(), sdf)){
+        LOG_ERROR("unabled to read sdf file %s.", filePath.toStdString().c_str());
+        return;
+    }
+
+    if (!sdf->root->HasElement("model")){
+        LOG_ERROR("the <model> tag not exists");
+        return;
+    }
+
+    sdf::ElementPtr sdf_model = sdf->root->GetElement("model");
+    base::JointLimits limits;
+
+    if (sdf_model->HasElement("joint")){
+        sdf::ElementPtr jointElem = sdf_model->GetElement("joint");
+
+        while (jointElem){
+            std::string joint_name = jointElem->Get<std::string>("name");
+            std::string joint_type = jointElem->Get<std::string>("type");
+
+            base::JointLimitRange range;
+
+            if (jointElem->HasElement("axis")){
+                sdf::ElementPtr axisElem = jointElem->GetElement("axis");
+
+                if (axisElem->HasElement("limit")){
+                    sdf::ElementPtr limitElem = axisElem->GetElement("limit");
+
+                    if (limitElem->HasElement("lower")){
+                        range.min.position = limitElem->Get<double>("lower");
+                    }
+
+                    if (limitElem->HasElement("upper")){
+                        range.max.position = limitElem->Get<double>("upper");
+                    }
+
+                    if (limitElem->HasElement("effort")){
+                        double effort  = limitElem->Get<double>("effort");
+                        range.min.effort = -effort;
+                        range.max.effort = effort;
+                    }
+
+                    if (limitElem->HasElement("velocity")){
+                        double speed  = limitElem->Get<double>("velocity");
+                        range.min.speed = -speed;
+                        range.max.speed = speed;
+                    }
+                }
+
+            }
+
+            limits.names.push_back(joint_name);
+            limits.elements.push_back(range);
+            jointElem = jointElem->GetNextElement("joint");
+        }
     }
 
     initModel(limits);

--- a/src/ControlUi.cc
+++ b/src/ControlUi.cc
@@ -71,7 +71,7 @@ void ControlUi::initFromFile(QString filepath, QString mode){
         return initFromURDF(filepath);
     else if (mode == "sdf")
         return initFromSDF(filepath);
-    else if (mode == "yaml")
+    else if (mode == "yml")
         return initFromYaml(filepath);
 }
 

--- a/src/ControlUi.cc
+++ b/src/ControlUi.cc
@@ -174,13 +174,14 @@ void ControlUi::initFromSDF(QString filePath)
     }
 
     sdf::ElementPtr sdf_model = sdf->root->GetElement("model");
+    std::string model_name = sdf_model->Get<std::string>("name");
     base::JointLimits limits;
 
     if (sdf_model->HasElement("joint")){
         sdf::ElementPtr jointElem = sdf_model->GetElement("joint");
 
         while (jointElem){
-            std::string joint_name = jointElem->Get<std::string>("name");
+            std::string joint_name = model_name + "::" + jointElem->Get<std::string>("name");
             std::string joint_type = jointElem->Get<std::string>("type");
 
             base::JointLimitRange range;

--- a/src/ControlUi.h
+++ b/src/ControlUi.h
@@ -37,6 +37,7 @@ public slots:
                    bool no_effort, bool no_velocity, double command_noise_std_dev = 0);
      void initFromYaml(QString filepath);
      void initFromURDF(QString filepath);
+     void initFromSDF(QString filePath);
      void initModel(const base::JointLimits &limits);
 
 protected slots:

--- a/src/ControlUi.h
+++ b/src/ControlUi.h
@@ -35,6 +35,8 @@ public slots:
      void layoutJointForms(int columns);
      void configureUi(double override_vel_limit, bool positive_vel_only,
                    bool no_effort, bool no_velocity, double command_noise_std_dev = 0);
+
+     void initFromFile(QString filepath, QString mode = "auto");
      void initFromYaml(QString filepath);
      void initFromURDF(QString filepath);
      void initFromSDF(QString filePath);

--- a/src/ControlUi.h
+++ b/src/ControlUi.h
@@ -40,6 +40,11 @@ public slots:
      void initFromYaml(QString filepath);
      void initFromURDF(QString filepath);
      void initFromSDF(QString filePath);
+
+     void initFromString(QString string, QString mode);
+     void initFromSDFString(QString string);
+     void initFromURDFString(QString string);
+
      void initModel(const base::JointLimits &limits);
 
 protected slots:


### PR DESCRIPTION
On the C++ side, this adds support loading an SDF model to setup the UI. On the Ruby side, it allows having task names with a colon (`:`) in them, which is how rock-gazebo handles the model hierarchy.