### PR TITLE
Consistently use urdf::JointSharedPtr.

### DIFF
--- a/src/ControlUi.cc
+++ b/src/ControlUi.cc
@@ -61,10 +61,10 @@ void ControlUi::initFromURDF(QString filepath){
     std::string xml((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
     urdf::ModelInterfaceSharedPtr urdf_model = urdf::parseURDF(xml);
 
-    std::map<std::string, urdf::JointSharedPtr >::iterator it;
+    std::map<std::string, urdf::JointSharedPtr >::const_iterator it;
     base::JointLimits limits;
     for (it=urdf_model->joints_.begin(); it!=urdf_model->joints_.end(); ++it){
-        std::shared_ptr<urdf::Joint> joint = it->second;
+        const urdf::JointSharedPtr &joint = it->second;
         base::JointLimitRange range;
 
         if(joint->type != urdf::Joint::FIXED && !joint->mimic){


### PR DESCRIPTION
This failed to build, if `urdf::JointSharedPtr` still is a `boost::shared_ptr`.
Also avoid unnecessary copy of shared pointers (this is a minor, but unnecessary overhead)
