### PR TITLE
fix static step sizes and decimals not usable for linear joints: dyna…

### DIFF
--- a/src/jointform.cpp
+++ b/src/jointform.cpp
@@ -8,19 +8,21 @@ JointForm::JointForm(QWidget *parent, Config config) :
 {
     ui->setupUi(this);
 
-    this->ui->slPos->setMinimum(-M_PI_4 * SLIDER_POS_SCALE_FACTOR);
-    this->ui->slPos->setMaximum(M_PI_4 * SLIDER_POS_SCALE_FACTOR);
-    this->ui->slVel->setMinimum(-M_PI_4 * SLIDER_VEL_SCALE_FACTOR);
-    this->ui->slVel->setMaximum(M_PI_4 * SLIDER_VEL_SCALE_FACTOR);
-    this->ui->slEff->setMinimum(-M_PI_4 * SLIDER_EFF_SCALE_FACTOR);
-    this->ui->slEff->setMaximum(M_PI_4 * SLIDER_EFF_SCALE_FACTOR);
+    this->ui->slPos->setMinimum(0);
+    this->ui->slPos->setMaximum(SLIDER_INCREMENTS);
+    this->ui->slVel->setMinimum(0);
+    this->ui->slVel->setMaximum(SLIDER_INCREMENTS);
+    this->ui->slEff->setMinimum(0);
+    this->ui->slEff->setMaximum(SLIDER_INCREMENTS);
 
-    this->ui->dsbPos->setMinimum(-M_PI_4);
-    this->ui->dsbPos->setMaximum(M_PI_4);
-    this->ui->dsbVel->setMinimum(-M_PI_4);
-    this->ui->dsbVel->setMaximum(M_PI_4);
-    this->ui->dsbEff->setMinimum(-M_PI_4);
-    this->ui->dsbEff->setMaximum(M_PI_4);
+    jointLimits.min.position = -M_PI_4;
+    jointLimits.max.position = +M_PI_4;
+    jointLimits.min.speed    = -M_PI_4;
+    jointLimits.max.speed    = +M_PI_4;
+    jointLimits.min.effort   = -1.0;
+    jointLimits.max.effort   = +1.0;
+    
+    setJointLimits();
 
     connect(this->ui->slPos, SIGNAL(valueChanged(int)), this, SLOT(handlePosSliderChange(int)));
     connect(this->ui->slVel, SIGNAL(valueChanged(int)), this, SLOT(handleVelSliderChange(int)));
@@ -51,44 +53,81 @@ JointForm::~JointForm()
     delete ui;
 }
 
+
+double JointForm::sliderValueToRealValue(const double& min, const double& max, const int& sliderValue) {
+    double value = (max - min) * (double)sliderValue / SLIDER_INCREMENTS + min;
+    return value;
+}
+
+double JointForm::sliderValueToRealPos(const int& sliderValue) {
+    return sliderValueToRealValue( jointLimits.min.position, jointLimits.max.position, sliderValue );
+}
+
+double JointForm::sliderValueToRealVel(const int& sliderValue) {
+    return sliderValueToRealValue( jointLimits.min.speed, jointLimits.max.speed, sliderValue );
+}
+
+double JointForm::sliderValueToRealEff(const int& sliderValue) {
+    return sliderValueToRealValue( jointLimits.min.effort, jointLimits.max.effort, sliderValue );
+}
+
+
+int JointForm::realValueTosliderValue(const double& min, const double& max, const double& realValue) {
+    double value = (realValue - min)/(max - min) * SLIDER_INCREMENTS;
+    return value;
+}
+
+int JointForm::realPosToSliderValue(const double& realValue) {
+    return realValueTosliderValue( jointLimits.min.position, jointLimits.max.position, realValue );
+}
+
+int JointForm::realVelToSliderValue(const double& realValue) {
+    return realValueTosliderValue( jointLimits.min.speed, jointLimits.max.speed, realValue );
+}
+
+int JointForm::realEffToSliderValue(const double& realValue) {
+    return realValueTosliderValue( jointLimits.min.effort, jointLimits.max.effort, realValue );
+}
+
+
 void JointForm::handlePosSliderChange(int val){
     this->ui->dsbPos->blockSignals(true);
-    this->ui->dsbPos->setValue((double)val/SLIDER_POS_SCALE_FACTOR);
+    this->ui->dsbPos->setValue(sliderValueToRealPos(val));
     this->ui->dsbPos->blockSignals(false);
     handleValueChange();
 }
 
 void JointForm::handleVelSliderChange(int val){
     this->ui->dsbVel->blockSignals(true);
-    this->ui->dsbVel->setValue((double)val/SLIDER_VEL_SCALE_FACTOR);
+    this->ui->dsbVel->setValue(sliderValueToRealVel(val));
     this->ui->dsbVel->blockSignals(false);
     handleValueChange();
 }
 
 void JointForm::handleEffSliderChange(int val){
     this->ui->dsbEff->blockSignals(true);
-    this->ui->dsbEff->setValue((double)val/SLIDER_EFF_SCALE_FACTOR);
+    this->ui->dsbEff->setValue(sliderValueToRealEff(val));
     this->ui->dsbEff->blockSignals(false);
     handleValueChange();
 }
 
 void JointForm::handlePosBoxChange(double val){
     this->ui->slPos->blockSignals(true);
-    this->ui->slPos->setValue(val*SLIDER_POS_SCALE_FACTOR);
+    this->ui->slPos->setValue(realPosToSliderValue(val));
     this->ui->slPos->blockSignals(false);
     handleValueChange();
 }
 
 void JointForm::handleVelBoxChange(double val){
     this->ui->slVel->blockSignals(true);
-    this->ui->slVel->setValue(val*SLIDER_VEL_SCALE_FACTOR);
+    this->ui->slVel->setValue(realVelToSliderValue(val));
     this->ui->slVel->blockSignals(false);
     handleValueChange();
 }
 
 void JointForm::handleEffBoxChange(double val){
     this->ui->slEff->blockSignals(true);
-    this->ui->slEff->setValue(val*SLIDER_EFF_SCALE_FACTOR);
+    this->ui->slEff->setValue(realEffToSliderValue(val));
     this->ui->slEff->blockSignals(false);
     handleValueChange();
 }
@@ -105,56 +144,82 @@ void JointForm::setName(std::string name)
     this->ui->lblName->setText(QString::fromStdString(name));
 }
 
-void JointForm::setJointLimit(double min, double max){
+
+double JointForm::calcSpinBoxStep(const double& min, const double& max) {
+    double step = pow(10, -calcSpinBoxDecimals(min, max));
+    return step;
+}
+
+int JointForm::calcSpinBoxDecimals(const double& min, const double& max) {
+    double decimals = 0;
+    double tmp = (max-min) / SPINBOX_STEPS;
+    
+    while ( tmp < 1 ) {
+        decimals++;
+        tmp *= 10;
+    }
+    
+    return decimals;
+}
+
+void JointForm::setJointLimits() {
     if(config.override_vel_limit){
-        min = -fabs(config.override_vel_limit);
-        max = fabs(min);
+        jointLimits.min.speed = -fabs(config.override_vel_limit);
+        jointLimits.max.speed = +fabs(config.override_vel_limit);
     }
     if(config.positive_vel_only){
-        min = 0.;
+        jointLimits.min.speed = 0;
     }
 
-    this->ui->slVel->setMinimum(min * SLIDER_VEL_SCALE_FACTOR);
-    this->ui->slVel->setMaximum(max * SLIDER_VEL_SCALE_FACTOR);
+    this->ui->dsbPos->setMinimum(jointLimits.min.position);
+    this->ui->dsbPos->setMaximum(jointLimits.max.position);
+    this->ui->dsbPos->setDecimals(
+        calcSpinBoxDecimals(jointLimits.min.position, jointLimits.max.position)
+    );
+    this->ui->dsbPos->setSingleStep(
+        calcSpinBoxStep(jointLimits.min.position, jointLimits.max.position)
+    );
+    
+    this->ui->dsbVel->setMinimum(jointLimits.min.speed);
+    this->ui->dsbVel->setMaximum(jointLimits.max.speed);
+    this->ui->dsbVel->setDecimals(
+        calcSpinBoxDecimals(jointLimits.min.speed, jointLimits.max.speed)
+    );
+    this->ui->dsbVel->setSingleStep(
+        calcSpinBoxStep(jointLimits.min.speed, jointLimits.max.speed)
+    );
 
-    this->ui->dsbVel->setMinimum(min);
-    this->ui->dsbVel->setMaximum(max);
+    this->ui->dsbEff->setMinimum(jointLimits.min.effort);
+    this->ui->dsbEff->setMaximum(jointLimits.max.effort);    
+    this->ui->dsbEff->setDecimals(
+        calcSpinBoxDecimals(jointLimits.min.effort, jointLimits.max.effort)
+    );
+    this->ui->dsbEff->setSingleStep(
+        calcSpinBoxStep(jointLimits.min.effort, jointLimits.max.effort)
+    );
 }
 
 void JointForm::initFromJointRange(const base::JointLimitRange& rng, std::string name){
     setName(name);
 
-    setJointLimit(rng.min.speed, rng.max.speed);
-
-    this->ui->slPos->setMinimum(rng.min.position * SLIDER_POS_SCALE_FACTOR);
-    this->ui->slPos->setMaximum(rng.max.position * SLIDER_POS_SCALE_FACTOR);
-
-    this->ui->slEff->setMinimum(rng.min.effort * SLIDER_EFF_SCALE_FACTOR);
-    this->ui->slEff->setMaximum(rng.max.effort * SLIDER_EFF_SCALE_FACTOR);
-
-    this->ui->dsbPos->setMinimum(rng.min.position);
-    this->ui->dsbPos->setMaximum(rng.max.position);
-
-    this->ui->dsbEff->setMinimum(rng.min.effort);
-    this->ui->dsbEff->setMaximum(rng.max.effort);
+    jointLimits = rng;
+    
+    setJointLimits();
 }
 
 void JointForm::initFromJointLimits(const urdf::JointLimits& limits, std::string name){
     setName(name);
-
-    setJointLimit(-limits.velocity, limits.velocity);
-
-    this->ui->slPos->setMinimum(limits.lower * SLIDER_POS_SCALE_FACTOR);
-    this->ui->slPos->setMaximum(limits.upper * SLIDER_POS_SCALE_FACTOR);
-
-    this->ui->slEff->setMinimum(-limits.effort * SLIDER_EFF_SCALE_FACTOR);
-    this->ui->slEff->setMaximum(limits.effort * SLIDER_EFF_SCALE_FACTOR);
-
-    this->ui->dsbPos->setMinimum(limits.lower);
-    this->ui->dsbPos->setMaximum(limits.upper);
-
-    this->ui->dsbEff->setMinimum(-limits.effort);
-    this->ui->dsbEff->setMaximum(limits.effort);
+    
+    jointLimits.min.position = limits.lower;
+    jointLimits.max.position = limits.upper;    
+    
+    jointLimits.min.speed = -limits.velocity;
+    jointLimits.max.speed = +limits.velocity;
+    
+    jointLimits.min.effort = -limits.effort;
+    jointLimits.max.effort = +limits.effort;
+    
+    setJointLimits();
 }
 
 
@@ -165,7 +230,7 @@ void JointForm::setJointState(const base::JointState& state)
         this->ui->dsbPos->setValue(state.position);
         this->ui->dsbPos->blockSignals(false);
         this->ui->slPos->blockSignals(true);
-        this->ui->slPos->setValue(state.position*SLIDER_POS_SCALE_FACTOR);
+        this->ui->slPos->setValue(realPosToSliderValue(state.position));
         this->ui->slPos->blockSignals(false);
     }
     if(state.hasSpeed()) {
@@ -173,7 +238,7 @@ void JointForm::setJointState(const base::JointState& state)
         this->ui->dsbVel->setValue(state.speed);
         this->ui->dsbVel->blockSignals(false);
         this->ui->slVel->blockSignals(true);
-        this->ui->slVel->setValue(state.speed*SLIDER_VEL_SCALE_FACTOR);
+        this->ui->slVel->setValue(realVelToSliderValue(state.speed));
         this->ui->slVel->blockSignals(false);
     }
     if(state.hasEffort()) {
@@ -181,7 +246,7 @@ void JointForm::setJointState(const base::JointState& state)
         this->ui->dsbEff->setValue(state.effort);
         this->ui->dsbEff->blockSignals(false);
         this->ui->slEff->blockSignals(true);
-        this->ui->slEff->setValue(state.effort*SLIDER_EFF_SCALE_FACTOR);
+        this->ui->slEff->setValue(realEffToSliderValue(state.effort));
         this->ui->slEff->blockSignals(false);
     }
 }

--- a/src/jointform.h
+++ b/src/jointform.h
@@ -5,10 +5,6 @@
 #include <base/JointLimitRange.hpp>
 #include <urdf_model/model.h>
 
-#define SLIDER_POS_SCALE_FACTOR 100.
-#define SLIDER_VEL_SCALE_FACTOR 100.
-#define SLIDER_EFF_SCALE_FACTOR 100.
-
 namespace Ui {
 class JointForm;
 }
@@ -35,7 +31,23 @@ public:
     void initFromJointLimits(const urdf::JointLimits& limits, std::string name);
     base::JointState getJointState();
     ~JointForm();
+    
+    const double SLIDER_INCREMENTS = 256.0;
+    const double SPINBOX_STEPS = 100.0;
 
+    double sliderValueToRealValue(const double& min, const double& max, const int& sliderValue);
+    double sliderValueToRealPos(const int& sliderValue);
+    double sliderValueToRealVel(const int& sliderValue);
+    double sliderValueToRealEff(const int& sliderValue);
+
+    int realValueTosliderValue(const double& min, const double& max, const double& realValue);
+    int realPosToSliderValue(const double& realValue);
+    int realVelToSliderValue(const double& realValue);
+    int realEffToSliderValue(const double& realValue);
+    
+    double calcSpinBoxStep(const double& min, const double& max);
+    int calcSpinBoxDecimals(const double& min, const double& max);
+    
 public slots:
     void setJointState(const base::JointState& state);
     void activate(bool active);
@@ -51,14 +63,16 @@ protected slots:
     void handlePosBoxChange(double val);
     void handleVelBoxChange(double val);
     void handleEffBoxChange(double val);
-    void setJointLimit(double min, double max);
+    void setJointLimits();
 
 signals:
     void valueChanged(std::string name, base::JointState state);
     
 private:
-    Ui::JointForm *ui;
     Config config;
+    Ui::JointForm *ui;
+    base::JointLimitRange jointLimits;
+    
 };
 
 #endif // JOINTFORM_H


### PR DESCRIPTION
…mic calculation of decimals and step sizes depending on joint limits added

Background: When using joint status' position field in SI unit meter for linear joints, the ui could not be used for small displacements because the increment was set to 0.01 = 1cm, which can be large for some joints. This change calculates the number of decimals from the range.